### PR TITLE
fixed mesh_morpher uninstal bug

### DIFF
--- a/mesh_morpher.py
+++ b/mesh_morpher.py
@@ -174,7 +174,7 @@ def unregister():
     bpy.utils.unregister_class(UT_MeshMorpherPanel)
     bpy.utils.unregister_class(UT_PackMorphTargetsOperator)
     bpy.utils.unregister_class(UT_MeshMorpherProperties)
-    del bpy.types.Scene.unreal_tools.mesh_morpher_properties
+    del bpy.types.Scene.mesh_morpher_properties
     
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
There was a bug when uninstalling the mesh_morpher script caused by a misnaming in the unregister function. This caused an error when uninstalling and the properties group created by the script to not be deleted.